### PR TITLE
Migrate admin interface to shadcn ui sidebar

### DIFF
--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -379,7 +379,7 @@ const ProductsView = ({
       return;
     }
     try {
-      await productsApi.delete(sessionToken, id);
+      await productsApi.remove(sessionToken, id);
       toast.success("Đã xoá sản phẩm");
       await loadList();
     } catch {

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,134 +1,17 @@
 "use client";
-import Link from "next/link";
-import { useMemo, useState } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
-import {
-  LayoutDashboard,
-  ShoppingBag,
-  Users,
-  Settings,
-  ClipboardList,
-  Menu,
-  Bell,
-  Search as SearchIcon,
-} from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-
-const navItems = [
-  { id: "dashboard", label: "Tổng Quan", icon: <LayoutDashboard size={18} /> },
-  { id: "orders", label: "Đơn Hàng", icon: <ClipboardList size={18} /> },
-  { id: "products", label: "Sản Phẩm", icon: <ShoppingBag size={18} /> },
-  { id: "accounts", label: "Tài Khoản", icon: <Users size={18} /> },
-  { id: "settings", label: "Cài Đặt", icon: <Settings size={18} /> },
-];
+import React from "react";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+import { SiteHeader } from "@/components/site-header";
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  const baseHref = useMemo(() => {
-    // assume dashboard is the base page for admin
-    return "/dashboard";
-  }, [pathname]);
-
-  const currentSection = searchParams?.get("section") || "dashboard";
-
   return (
-    <div className="flex min-h-screen bg-gray-100 text-gray-800">
-      {/* Desktop sidebar */}
-      <aside className="hidden lg:flex lg:flex-col w-64 bg-white shadow-lg">
-        <div className="h-20 border-b flex items-center px-6">
-          <div className="h-10 w-10 rounded-md bg-pink-100 text-pink-600 flex items-center justify-center font-bold">
-            L
-          </div>
-          <div className="ml-3">
-            <div className="font-bold">LALA-LYCHEE</div>
-            <div className="text-xs text-muted-foreground">Admin</div>
-          </div>
-        </div>
-        <nav className="flex-1 py-4">
-          {navItems.map((item) => {
-            const href = `${baseHref}?section=${item.id}`;
-            const isActive = currentSection === item.id;
-            return (
-              <Link
-                key={item.id}
-                href={href}
-                className={`flex items-center gap-3 py-3 px-6 my-1 transition-colors ${
-                  isActive
-                    ? "bg-pink-100 text-pink-600 border-r-4 border-pink-600"
-                    : "text-gray-600 hover:bg-gray-100"
-                }`}
-              >
-                {item.icon}
-                <span className="font-medium">{item.label}</span>
-              </Link>
-            );
-          })}
-        </nav>
-      </aside>
-
-      {/* Mobile drawer */}
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-40 lg:hidden">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setSidebarOpen(false)}></div>
-          <aside className="relative z-10 w-64 h-full bg-white shadow-lg flex flex-col">
-            <div className="h-16 border-b flex items-center px-4">
-              <div className="h-9 w-9 rounded-md bg-pink-100 text-pink-600 flex items-center justify-center font-bold">
-                L
-              </div>
-              <div className="ml-2 font-semibold">LALA-LYCHEE</div>
-            </div>
-            <nav className="flex-1 py-3">
-              {navItems.map((item) => {
-                const href = `${baseHref}?section=${item.id}`;
-                const isActive = currentSection === item.id;
-                return (
-                  <Link
-                    key={item.id}
-                    href={href}
-                    onClick={() => setSidebarOpen(false)}
-                    className={`flex items-center gap-3 py-3 px-4 my-1 transition-colors ${
-                      isActive ? "bg-pink-100 text-pink-600" : "text-gray-600 hover:bg-gray-100"
-                    }`}
-                  >
-                    {item.icon}
-                    <span className="font-medium">{item.label}</span>
-                  </Link>
-                );
-              })}
-            </nav>
-          </aside>
-        </div>
-      )}
-
-      {/* Main area */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <header className="bg-white shadow-sm h-16 flex items-center justify-between px-4 lg:px-8">
-          <div className="flex items-center gap-3">
-            <Button variant="ghost" size="icon" className="lg:hidden" onClick={() => setSidebarOpen(true)}>
-              <Menu size={20} />
-            </Button>
-            <div className="hidden md:flex items-center bg-gray-100 px-3 py-2 rounded-lg">
-              <SearchIcon className="text-gray-500" size={18} />
-              <Input placeholder="Tìm kiếm..." className="bg-transparent border-0 focus-visible:ring-0 ml-2 w-[260px]" />
-            </div>
-          </div>
-          <div className="flex items-center gap-4">
-            <Bell className="text-gray-500" size={20} />
-            <div className="flex items-center gap-2">
-              <img src="https://placehold.co/36x36/fecdd3/be185d?text=A" alt="Admin" className="w-9 h-9 rounded-full" />
-              <div className="hidden md:block">
-                <div className="text-sm font-medium">Admin</div>
-                <div className="text-xs text-muted-foreground">Quản trị viên</div>
-              </div>
-            </div>
-          </div>
-        </header>
-        <main className="flex-1 overflow-x-hidden overflow-y-auto p-4 md:p-8">{children}</main>
-      </div>
-    </div>
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <SiteHeader />
+        <main className="p-4 md:p-8">{children}</main>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }

--- a/src/app/(auth)/account/page.tsx
+++ b/src/app/(auth)/account/page.tsx
@@ -1,9 +1,9 @@
-import { useAppProviderContext } from "@/context/app-context";
+import { useAppContextProvider } from "@/context/app-context";
 import { cookies } from "next/headers";
 import React from "react";
 
 export default function Page() {
-  const { setSessionToken } = useAppProviderContext();
+  const { setSessionToken } = useAppContextProvider();
 
   return <div className="mt-25"></div>;
 }

--- a/src/app/api/orders/[orderId]/history/route.ts
+++ b/src/app/api/orders/[orderId]/history/route.ts
@@ -3,11 +3,12 @@ import { proxyJson } from "@/lib/next-api-auth";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { orderId: string } }
+  context: any
 ) {
   try {
+    const orderId = context?.params?.orderId as string;
     return proxyJson(
-      `${process.env.NEXT_PUBLIC_API_END_POINT}/v1/api/orders/${params.orderId}/history`,
+      `${process.env.NEXT_PUBLIC_API_END_POINT}/v1/api/orders/${orderId}/history`,
       request,
       { method: "GET", requireAuth: true }
     );

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -4,9 +4,9 @@ import { proxyJson } from "@/lib/next-api-auth";
 
 export async function GET(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  context: any
 ) {
-  const id = params.id;
+  const id = context?.params?.id as string;
   try {
     const base = envConfig.NEXT_PUBLIC_API_END_POINT;
     const template = process.env.API_PRODUCTS_GET_URL_TEMPLATE; // e.g., /v1/api/products/public/{id}
@@ -60,9 +60,9 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  context: any
 ) {
-  const id = params.id;
+  const id = context?.params?.id as string;
   try {
     const body = await request.json();
     const base = envConfig.NEXT_PUBLIC_API_END_POINT;
@@ -109,9 +109,9 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  context: any
 ) {
-  const id = params.id;
+  const id = context?.params?.id as string;
   try {
     const base = envConfig.NEXT_PUBLIC_API_END_POINT;
     const template = process.env.API_PRODUCTS_DELETE_URL_TEMPLATE; // e.g., /v1/api/products/{id}

--- a/src/app/api/products/public/[id]/route.ts
+++ b/src/app/api/products/public/[id]/route.ts
@@ -3,9 +3,9 @@ import { envConfig } from "@/config";
 
 export async function GET(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  context: any
 ) {
-  const id = params.id;
+  const id = context?.params?.id as string;
   try {
     const res = await fetch(
       `${envConfig.NEXT_PUBLIC_API_END_POINT}/v1/api/products/public/${id}`,

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,0 +1,97 @@
+"use client";
+import Link from "next/link";
+import { useMemo } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { LayoutDashboard, ShoppingBag, Users, Settings, ClipboardList } from "lucide-react";
+import { useSidebar } from "@/components/ui/sidebar";
+
+const navItems = [
+  { id: "dashboard", label: "Tổng Quan", icon: <LayoutDashboard size={18} /> },
+  { id: "orders", label: "Đơn Hàng", icon: <ClipboardList size={18} /> },
+  { id: "products", label: "Sản Phẩm", icon: <ShoppingBag size={18} /> },
+  { id: "accounts", label: "Tài Khoản", icon: <Users size={18} /> },
+  { id: "settings", label: "Cài Đặt", icon: <Settings size={18} /> },
+];
+
+export function AppSidebar() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { isOpen, close } = useSidebar();
+
+  const baseHref = useMemo(() => {
+    return "/dashboard";
+  }, [pathname]);
+
+  const currentSection = searchParams?.get("section") || "dashboard";
+
+  return (
+    <>
+      <aside className="hidden lg:flex fixed left-0 top-0 h-svh w-64 bg-white border-r shadow-sm z-40 flex-col">
+        <div className="h-16 border-b flex items-center px-6">
+          <div className="h-9 w-9 rounded-md bg-pink-100 text-pink-600 flex items-center justify-center font-bold">
+            L
+          </div>
+          <div className="ml-3">
+            <div className="font-bold">LALA-LYCHEE</div>
+            <div className="text-xs text-muted-foreground">Admin</div>
+          </div>
+        </div>
+        <nav className="flex-1 py-3 overflow-y-auto">
+          {navItems.map((item) => {
+            const href = `${baseHref}?section=${item.id}`;
+            const isActive = currentSection === item.id;
+            return (
+              <Link
+                key={item.id}
+                href={href}
+                className={`flex items-center gap-3 py-3 px-6 my-0.5 transition-colors ${
+                  isActive
+                    ? "bg-pink-100 text-pink-600 border-r-4 border-pink-600"
+                    : "text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                {item.icon}
+                <span className="font-medium">{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </aside>
+
+      {isOpen && (
+        <div className="lg:hidden fixed inset-0 z-50">
+          <div className="absolute inset-0 bg-black/50" onClick={close}></div>
+          <aside className="relative z-10 w-64 h-full bg-white shadow-lg flex flex-col">
+            <div className="h-16 border-b flex items-center px-4">
+              <div className="h-9 w-9 rounded-md bg-pink-100 text-pink-600 flex items-center justify-center font-bold">
+                L
+              </div>
+              <div className="ml-2 font-semibold">LALA-LYCHEE</div>
+            </div>
+            <nav className="flex-1 py-3">
+              {navItems.map((item) => {
+                const href = `${baseHref}?section=${item.id}`;
+                const isActive = currentSection === item.id;
+                return (
+                  <Link
+                    key={item.id}
+                    href={href}
+                    onClick={close}
+                    className={`flex items-center gap-3 py-3 px-4 my-0.5 transition-colors ${
+                      isActive ? "bg-pink-100 text-pink-600" : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    {item.icon}
+                    <span className="font-medium">{item.label}</span>
+                  </Link>
+                );
+              })}
+            </nav>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default AppSidebar;

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Bell, Menu, Search as SearchIcon } from "lucide-react";
+import { useSidebar } from "@/components/ui/sidebar";
+
+export function SiteHeader() {
+  const { toggle } = useSidebar();
+
+  return (
+    <header className="bg-white border-b h-16 sticky top-0 z-30 flex items-center justify-between px-4 lg:px-8">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" className="lg:hidden" onClick={toggle}>
+          <Menu size={20} />
+        </Button>
+        <div className="hidden md:flex items-center bg-gray-100 px-3 py-2 rounded-lg">
+          <SearchIcon className="text-gray-500" size={18} />
+          <Input placeholder="Tìm kiếm..." className="bg-transparent border-0 focus-visible:ring-0 ml-2 w-[260px]" />
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <Bell className="text-gray-500" size={20} />
+        <div className="flex items-center gap-2">
+          <img src="https://placehold.co/36x36/fecdd3/be185d?text=A" alt="Admin" className="w-9 h-9 rounded-full" />
+          <div className="hidden md:block">
+            <div className="text-sm font-medium">Admin</div>
+            <div className="text-xs text-muted-foreground">Quản trị viên</div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default SiteHeader;

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,36 @@
+"use client";
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+type SidebarContextValue = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+};
+
+const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
+
+export function SidebarProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  const value = useMemo(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle]
+  );
+
+  return <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>;
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext);
+  if (!ctx) throw new Error("useSidebar must be used within SidebarProvider");
+  return ctx;
+}
+
+export function SidebarInset({ children }: { children: React.ReactNode }) {
+  return <div className="lg:pl-64">{children}</div>;
+}

--- a/src/layouts/layout-main.tsx
+++ b/src/layouts/layout-main.tsx
@@ -7,7 +7,7 @@ import Footer from "./Footer";
 function LayoutMain({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   // check page admin
-  const isAdminPage = pathname.startsWith("/quantri");
+  const isAdminPage = pathname.startsWith("/dashboard");
   return (
     <div>
       {!isAdminPage && <Header />}


### PR DESCRIPTION
Refactor the admin dashboard layout to use a shadcn/ui-style sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0ad63e1-4e7f-44ad-8412-8863abfcb0d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0ad63e1-4e7f-44ad-8412-8863abfcb0d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

